### PR TITLE
chore: add small adjustements to improve Pipeline Best Practices

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,26 +6,39 @@ on:
     branches:
       - main
 
+# Prevent simultaneous main pushes from racing over :latest Docker tag and release assets.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      hytale-version: ${{ steps.hytale-version.outputs.version }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Get project version
+        id: version
+        run: |
+          version=$(grep -oP '(?<=version = ").*(?=")' build.gradle.kts)
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -54,10 +67,14 @@ jobs:
 
       - name: Cache Hytale assets
         id: cache-hytale
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: hytale-home
           key: hytale-assets-pre-release-${{ steps.hytale-version.outputs.version }}
+          # Fall back to the most recent entry if the exact version key is missing
+          # (e.g. after a -print-version network error) to avoid a full 1.4 GB re-download.
+          restore-keys: |
+            hytale-assets-pre-release-
 
       # Extracts into the install path expected by the dev.scaffoldit plugin:
       # $hytale.home_path/install/$patchline/package/game/$version/Assets.zip
@@ -75,46 +92,90 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if [ -f ./.hytale-downloader-credentials.json ]; then
-            cat ./.hytale-downloader-credentials.json | gh secret set HYTALE_AUTH_JSON --repo ${{ github.repository }}
+            cat ./.hytale-downloader-credentials.json | gh secret set HYTALE_AUTH_JSON --repo "$GH_REPO"
           fi
+          rm -f ./.hytale-downloader-credentials.json
 
       - name: Build
         run: ./gradlew build -Phytale.home_path=${{ github.workspace }}/hytale-home
 
-      - name: Package JAR
-        if: github.ref == 'refs/heads/main'
-        run: ./gradlew jar -Phytale.home_path=${{ github.workspace }}/hytale-home
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: test-reports
+          path: build/reports/
 
-      - name: Remove sources JAR
-        run: rm -f build/libs/*-sources.jar
+      # Upload the plugin JAR (excluding sources) so the publish job can use it
+      # without re-running the full build.
+      - name: Upload JAR artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: plugin-jar
+          path: |
+            build/libs/Wartale-*.jar
+            !build/libs/*-sources.jar
+
+  publish:
+    name: Publish
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Restore the Hytale server files cached by the build job. The matching cache key
+      # guarantees a hit within the same workflow run without re-downloading 1.4 GB.
+      - name: Restore Hytale assets from cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: hytale-home
+          key: hytale-assets-pre-release-${{ needs.build.outputs.hytale-version }}
+          restore-keys: |
+            hytale-assets-pre-release-
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: plugin-jar
+          path: build/libs/
 
       - name: Set image name
-        if: github.ref == 'refs/heads/main'
         id: image
-        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: echo "name=ghcr.io/$(echo "$GH_REPO" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           file: docker/Dockerfile
           push: true
-          tags: ${{ steps.image.outputs.name }}:latest
+          # Tag with semver and commit SHA to enable precise rollbacks; :latest for convenience.
+          tags: |
+            ${{ steps.image.outputs.name }}:latest
+            ${{ steps.image.outputs.name }}:${{ needs.build.outputs.version }}
+            ${{ steps.image.outputs.name }}:${{ github.sha }}
 
       - name: Release JAR
-        if: github.ref == 'refs/heads/main'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         with:
-          tag_name: latest
+          tag_name: v${{ needs.build.outputs.version }}
           files: build/libs/Wartale-*.jar


### PR DESCRIPTION
This Pr focuses on adjusting the new pipeline to add security hardening and some best practices.

Following Points and changes have been made:
- Add Hashes instead of number for versions to prevent potential supply-chain-attacks by using the immutable commit instead of tag version
- Credentials do not get removed after use. This could be exploited
- Removed gradlew jar since this redundant imho
- Add concurrency to prevent race condition for docker image