### PR TITLE
feat: use inheritence for armor items

### DIFF
--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V2.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Chest",
   "TranslationProperties": {
-    "Name": "Cadian Chestplate"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Chest.png",
-  "IconProperties": {
-    "Scale": 0.45,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -61
-    ]
+    "Name": "Cadian Chestplate 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_ChestV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_Chest_Texture.png",
@@ -43,67 +24,5 @@
         "ResourceTypeId": "Cadian_Chest_Type"
       }
     ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Chest",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Overtop",
-      "Cape"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 20,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
-    ]
-  },
-  "Set": "Cadian_Chest_Type",
-  "ResourceTypes": [
-    {
-      "Id": "Cadian_Chest_Type"
-    }
-  ]
+  }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V3.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Chest",
   "TranslationProperties": {
-    "Name": "Cadian Chestplate"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Chest.png",
-  "IconProperties": {
-    "Scale": 0.45,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -61
-    ]
+    "Name": "Cadian Chestplate 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_ChestV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_Chest_TextureV2.png",
@@ -43,67 +24,5 @@
         "ResourceTypeId": "Cadian_Chest_Type"
       }
     ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Chest",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Overtop",
-      "Cape"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 20,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
-    ]
-  },
-  "Set": "Cadian_Chest_Type",
-  "ResourceTypes": [
-    {
-      "Id": "Cadian_Chest_Type"
-    }
-  ]
+  }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V4.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Chest_V4.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Chest",
   "TranslationProperties": {
-    "Name": "Cadian Chestplate"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Chest.png",
-  "IconProperties": {
-    "Scale": 0.45,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -61
-    ]
+    "Name": "Cadian Chestplate 3"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_ChestV4.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Chest/Armor_Cadian_Chest_TextureV2.png",
@@ -43,67 +24,5 @@
         "ResourceTypeId": "Cadian_Chest_Type"
       }
     ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Chest",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Overtop",
-      "Cape"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 20,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
-    ]
-  },
-  "Set": "Cadian_Chest_Type",
-  "ResourceTypes": [
-    {
-      "Id": "Cadian_Chest_Type"
-    }
-  ]
+  }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands.json
@@ -103,5 +103,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Cadian_Hands_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Cadian_Hands_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands_V2.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Cadian_Hands",
   "TranslationProperties": {
-    "Name": "Cadian_Gauntlets"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Hands.png",
-  "IconProperties": {
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Scale": 0.92,
-    "Translation": [
-      15,
-      -33
-    ]
+    "Name": "Cadian_Gauntlets 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Hands/Armor_Cadian_HandsV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Hands/Armor_Cadian_Hands_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Cadian_Hands",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,58 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Hands",
-    "BaseDamageResistance": 0,
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 5,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Cadian_Hands",
+        "ResourceTypeId": "Cadian_Hands_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Hands_V3.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Cadian_Hands",
   "TranslationProperties": {
-    "Name": "Cadian_Gauntlets"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Hands.png",
-  "IconProperties": {
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Scale": 0.92,
-    "Translation": [
-      15,
-      -33
-    ]
+    "Name": "Cadian_Gauntlets 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Hands/Armor_Cadian_HandsV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Hands/Armor_Cadian_Hands_TextureV2.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Cadian_Hands",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,58 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Hands",
-    "BaseDamageResistance": 0,
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 5,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Cadian_Hands",
+        "ResourceTypeId": "Cadian_Hands_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head.json
@@ -109,5 +109,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Cadian_Head_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Cadian_Head_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V2.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Head",
   "TranslationProperties": {
-    "Name": "Cadian Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Cadian Helmet 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_HeadV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_Head_Texture.png",
@@ -39,66 +20,9 @@
     "TimeSeconds": 0,
     "Input": [
       {
-        "ItemId": "Armor_Cadian_Head"
+        "ItemId": "Armor_Cadian_Head",
+        "ResourceTypeId": "Cadian_Head_Type"
       }
-    ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V3.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Head",
   "TranslationProperties": {
-    "Name": "Cadian Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Cadian Helmet 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_HeadV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_Head_Texture.png",
@@ -39,66 +20,9 @@
     "TimeSeconds": 0,
     "Input": [
       {
-        "ItemId": "Armor_Cadian_Head"
+        "ItemId": "Armor_Cadian_Head",
+        "ResourceTypeId": "Cadian_Head_Type"
       }
-    ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V4.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V4.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Head",
   "TranslationProperties": {
-    "Name": "Cadian Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Cadian Helmet 3"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_HeadV4.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_Head_TextureSkulless.png",
@@ -39,66 +20,9 @@
     "TimeSeconds": 0,
     "Input": [
       {
-        "ItemId": "Armor_Cadian_Head"
+        "ItemId": "Armor_Cadian_Head",
+        "ResourceTypeId": "Cadian_Head_Type"
       }
-    ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V5.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V5.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Head",
   "TranslationProperties": {
-    "Name": "Cadian Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Cadian Helmet 4"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_HeadV5.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_Head_TextureSkulless.png",
@@ -39,66 +20,9 @@
     "TimeSeconds": 0,
     "Input": [
       {
-        "ItemId": "Armor_Cadian_Head"
+        "ItemId": "Armor_Cadian_Head",
+        "ResourceTypeId": "Cadian_Head_Type"
       }
-    ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V7.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Head_V7.json
@@ -1,26 +1,7 @@
 {
+  "Parent": "Armor_Cadian_Head",
   "TranslationProperties": {
-    "Name": "Cadian Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Cadian Helmet 5"
   },
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_HeadV7.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Head/Armor_Cadian_Head_TextureHeadless.png",
@@ -39,66 +20,9 @@
     "TimeSeconds": 0,
     "Input": [
       {
-        "ItemId": "Armor_Cadian_Head"
+        "ItemId": "Armor_Cadian_Head",
+        "ResourceTypeId": "Cadian_Head_Type"
       }
-    ]
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs.json
@@ -95,5 +95,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Cadian_Legs_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Cadian_Legs_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V2.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Cadian_Legs",
   "TranslationProperties": {
-    "Name": "Cadian Greaves"
+    "Name": "Cadian Greaves 1"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_LegsV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Cadian_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Cadian_Legs",
+        "ResourceTypeId": "Cadian_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V3.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Cadian_Legs",
   "TranslationProperties": {
-    "Name": "Cadian Greaves"
+    "Name": "Cadian Greaves 2"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_LegsV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Cadian_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Cadian_Legs",
+        "ResourceTypeId": "Cadian_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V4.json
+++ b/src/main/resources/Server/Item/Items/Armors/Cadian_Guardsman/Armor_Cadian_Legs_V4.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Cadian_Legs",
   "TranslationProperties": {
-    "Name": "Cadian Greaves"
+    "Name": "Cadian Greaves 3"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_LegsV4.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Cadian/Armor_Cadian_Legs/Armor_Cadian_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Cadian_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Cadian_Legs",
+        "ResourceTypeId": "Cadian_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest.json
@@ -107,5 +107,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Sirdar_Chest_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Sirdar_Chest_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest_V2.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Chest",
   "TranslationProperties": {
-    "Name": "Sirdar Chestplate"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Chest.png",
-  "IconProperties": {
-    "Scale": 0.45,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -67
-    ]
+    "Name": "Sirdar Chestplate 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Chest/Armor_Sirdar_ChestV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Chest/Armor_Sirdar_Chest_Texture_Spiked.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Chest",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Chest",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Overtop",
-      "Cape"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 20,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Chest",
+        "ResourceTypeId": "Sirdar_Chest_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Chest_V3.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Chest",
   "TranslationProperties": {
-    "Name": "Sirdar Chestplate"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Chest.png",
-  "IconProperties": {
-    "Scale": 0.45,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -67
-    ]
+    "Name": "Sirdar Chestplate 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Chest/Armor_Sirdar_ChestV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Chest/Armor_Sirdar_Chest_Texture_Spiked.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Chest",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Chest",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Overtop",
-      "Cape"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.13,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 20,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Chest",
+        "ResourceTypeId": "Sirdar_Chest_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands.json
@@ -103,5 +103,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Sirdar_Hands_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Sirdar_Hands_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands_V2.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Hands",
   "TranslationProperties": {
-    "Name": "Sirdar Gauntlets"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Hands.png",
-  "IconProperties": {
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Scale": 0.92,
-    "Translation": [
-      15,
-      -33
-    ]
+    "Name": "Sirdar Gauntlets 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Hands/Armor_Sirdar_HandsV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Armor/Sirdar/Armor_Sirdar_Hands_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Hands",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,58 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Hands",
-    "BaseDamageResistance": 0,
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 5,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Hands",
+        "ResourceTypeId": "Sirdar_Hands_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Hands_V3.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Hands",
   "TranslationProperties": {
-    "Name": "Sirdar Gauntlets"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Hands.png",
-  "IconProperties": {
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Scale": 0.92,
-    "Translation": [
-      15,
-      -33
-    ]
+    "Name": "Sirdar Gauntlets 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Hands/Armor_Sirdar_HandsV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Armor/Sirdar/Armor_Sirdar_Hands_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Hands",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,58 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Hands",
-    "BaseDamageResistance": 0,
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.05,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 5,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Hands",
+        "ResourceTypeId": "Sirdar_Hands_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head.json
@@ -109,5 +109,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Sirdar_Head_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Sirdar_Head_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V2.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Head",
   "TranslationProperties": {
-    "Name": "Sirdar Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Sirdar Helmet 1"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_HeadV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_Head_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Head",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,64 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Head",
+        "ResourceTypeId": "Sirdar_Head_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V3.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Head",
   "TranslationProperties": {
-    "Name": "Sirdar Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Sirdar Helmet 2"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_HeadV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_Head_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Head",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,64 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Head",
+        "ResourceTypeId": "Sirdar_Head_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V4.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Head_V4.json
@@ -1,36 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Head",
   "TranslationProperties": {
-    "Name": "Sirdar Helmet"
-  },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Head.png",
-  "IconProperties": {
-    "Scale": 0.5,
-    "Rotation": [
-      22.5,
-      45,
-      22.5
-    ],
-    "Translation": [
-      0,
-      -2
-    ]
+    "Name": "Sirdar Helmet 3"
   },
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_HeadV4.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Head/Armor_Sirdar_Head_Texture_Headless.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Head",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -42,64 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Head",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "EarAccessory",
-      "Ear",
-      "Haircut",
-      "HeadAccessory"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.06,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 10,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Head",
+        "ResourceTypeId": "Sirdar_Head_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs.json
@@ -95,5 +95,11 @@
     "Family": [
       "Iron"
     ]
-  }
+  },
+  "Set": "Sirdar_Legs_Type",
+  "ResourceTypes": [
+    {
+      "Id": "Sirdar_Legs_Type"
+    }
+  ]
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V2.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V2.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Legs",
   "TranslationProperties": {
-    "Name": "Sirdar Greaves"
+    "Name": "Sirdar Greaves 1"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Legs/Armor_Sirdar_LegsV2.blockymodel",
   "Texture": "Resources/Items/Warhammer/Armor/Sirdar/Armor_Sirdar_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Legs",
+        "ResourceTypeId": "Sirdar_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V3.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V3.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Legs",
   "TranslationProperties": {
-    "Name": "Sirdar Greaves"
+    "Name": "Sirdar Greaves 2"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Legs/Armor_Sirdar_LegsV3.blockymodel",
   "Texture": "Resources/Items/Warhammer/Armor/Sirdar/Armor_Sirdar_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Legs",
+        "ResourceTypeId": "Sirdar_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V4.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V4.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Legs",
   "TranslationProperties": {
-    "Name": "Sirdar Greaves"
+    "Name": "Sirdar Greaves 3"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Legs/Armor_Sirdar_LegsV4.blockymodel",
   "Texture": "Resources/Items/Warhammer/Armor/Sirdar/Armor_Sirdar_Legs_Texture.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Legs",
+        "ResourceTypeId": "Sirdar_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V5.json
+++ b/src/main/resources/Server/Item/Items/Armors/Sirdar/Armor_Sirdar_Legs_V5.json
@@ -1,24 +1,11 @@
 {
+  "Parent": "Armor_Sirdar_Legs",
   "TranslationProperties": {
-    "Name": "Sirdar Greaves"
+    "Name": "Sirdar Greaves 4"
   },
-  "Quality": "Uncommon",
-  "ItemLevel": 20,
-  "PlayerAnimationsId": "Block",
-  "ItemSoundSetId": "ISS_Armor_Heavy",
-  "Categories": [
-    "Items.Armors"
-  ],
-  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Legs.png",
   "Model": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Legs/Armor_Sirdar_LegsV5.blockymodel",
   "Texture": "Resources/Items/Warhammer/Variants/Sirdar/Armor_Sirdar_Legs/Armor_Sirdar_Legs_Texture_Shredded.png",
   "Recipe": {
-    "Input": [
-      {
-        "ItemId": "Armor_Sirdar_Legs",
-        "Quantity": 1
-      }
-    ],
     "BenchRequirement": [
       {
         "Id": "Styling",
@@ -30,62 +17,12 @@
       }
     ],
     "KnowledgeRequired": false,
-    "TimeSeconds": 0
-  },
-  "Interactions": {
-    "Primary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    },
-    "Secondary": {
-      "Interactions": [
-        {
-          "Type": "EquipItem"
-        }
-      ]
-    }
-  },
-  "Armor": {
-    "ArmorSlot": "Legs",
-    "BaseDamageResistance": 0,
-    "CosmeticsToHide": [
-      "Pants",
-      "Shoes"
-    ],
-    "DamageResistance": {
-      "Physical": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ],
-      "Projectile": [
-        {
-          "Amount": 0.08,
-          "CalculationType": "Percent"
-        }
-      ]
-    },
-    "StatModifiers": {
-      "Health": [
-        {
-          "Amount": 15,
-          "CalculationType": "Additive"
-        }
-      ]
-    }
-  },
-  "MaxDurability": 110,
-  "DurabilityLossOnHit": 0.5,
-  "Tags": {
-    "Type": [
-      "Armor"
-    ],
-    "Family": [
-      "Iron"
+    "TimeSeconds": 0,
+    "Input": [
+      {
+        "ItemId": "Armor_Sirdar_Legs",
+        "ResourceTypeId": "Sirdar_Legs_Type"
+      }
     ]
   }
 }

--- a/src/main/resources/Server/Item/Items/Crafting/Bench_Styling.json
+++ b/src/main/resources/Server/Item/Items/Crafting/Bench_Styling.json
@@ -72,13 +72,8 @@
     "Bench": {
       "Type": "StructuralCrafting",
       "Id": "Styling",
-      "AllowBlockGroupCycling": true,
+      "AllowBlockGroupCycling": false,
       "AlwaysShowInventoryHints": true,
-      "HeaderCategories": [
-        "WoodPlanks",
-        "OrnatePlanks",
-        "DecorativePlanks"
-      ],
       "LocalOpenSoundEventId": "SFX_Workbench_Open",
       "LocalCloseSoundEventId": "SFX_Workbench_Close",
       "CompletedSoundEventId": "SFX_Workbench_Craft",
@@ -90,6 +85,7 @@
         "Variant3"
       ]
     },
+
     "BlockEntity": {
       "Components": {
         "BenchBlock": {}

--- a/src/main/resources/Server/Item/ResourceTypes/Cadian_Chest_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Cadian_Chest_Type.json
@@ -1,3 +1,3 @@
 {
-  "Icon": "Icons/ResourceTypes/Wood_Planks.png"
+  "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Chest.png"
 }

--- a/src/main/resources/Server/Item/ResourceTypes/Cadian_Hands_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Cadian_Hands_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Hands.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Cadian_Head_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Cadian_Head_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Head.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Cadian_Legs_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Cadian_Legs_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Cadian_Guardsman/Armor_Cadian_Legs.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Sirdar_Chest_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Sirdar_Chest_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Chest.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Sirdar_Hands_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Sirdar_Hands_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Hands.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Sirdar_Head_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Sirdar_Head_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Head.png" }

--- a/src/main/resources/Server/Item/ResourceTypes/Sirdar_Legs_Type.json
+++ b/src/main/resources/Server/Item/ResourceTypes/Sirdar_Legs_Type.json
@@ -1,0 +1,1 @@
+{ "Icon": "Icons/ItemsGenerated/Warhammer/Armors/Sirdar/Armor_Sirdar_Legs.png" }


### PR DESCRIPTION
# description:
This PR focuses on implementing the open tasks for the armor variants. It includes:
- Use parent inheritance for variant item JSON files
- Fix Cadian_Chest_Type resource type icon
- Styling Bench (Servitor) visual and interaction

Closes #345 